### PR TITLE
feat: add WebSocket support and interactive control TUI

### DIFF
--- a/cmd/connection.go
+++ b/cmd/connection.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Kaz Walker, Thermoquad
+
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"go.bug.st/serial"
+	"golang.org/x/term"
+)
+
+// Connection provides a common interface for reading/writing bytes from serial or WebSocket
+type Connection interface {
+	io.Reader
+	io.Writer
+	io.Closer
+}
+
+// ByteReader is an alias for backward compatibility
+type ByteReader = Connection
+
+// SerialConnection wraps a serial port
+type SerialConnection struct {
+	port serial.Port
+}
+
+func (s *SerialConnection) Read(p []byte) (int, error) {
+	return s.port.Read(p)
+}
+
+func (s *SerialConnection) Write(p []byte) (int, error) {
+	return s.port.Write(p)
+}
+
+func (s *SerialConnection) Close() error {
+	return s.port.Close()
+}
+
+// ErrConnectionClosed is returned when reading from a closed WebSocket connection
+var ErrConnectionClosed = fmt.Errorf("websocket connection closed")
+
+// WebSocketConnection wraps a WebSocket connection for byte-level reading
+type WebSocketConnection struct {
+	conn      *websocket.Conn
+	buf       []byte
+	bufOffset int
+	closed    bool // Track if connection has failed/closed
+}
+
+func (w *WebSocketConnection) Read(p []byte) (int, error) {
+	// Return immediately if connection is known to be closed
+	if w.closed {
+		return 0, ErrConnectionClosed
+	}
+
+	// If we have buffered data, return it first
+	if w.bufOffset < len(w.buf) {
+		n := copy(p, w.buf[w.bufOffset:])
+		w.bufOffset += n
+		return n, nil
+	}
+
+	// Read next message from WebSocket (non-recursive loop to avoid stack overflow)
+	for {
+		messageType, data, err := w.conn.ReadMessage()
+		if err != nil {
+			// Mark connection as closed to prevent further read attempts
+			w.closed = true
+			return 0, err
+		}
+
+		// We only handle binary messages for Fusain protocol
+		if messageType != websocket.BinaryMessage {
+			// Skip non-binary messages and continue loop
+			continue
+		}
+
+		// Buffer the message and return what fits
+		w.buf = data
+		w.bufOffset = 0
+		n := copy(p, w.buf)
+		w.bufOffset = n
+		return n, nil
+	}
+}
+
+func (w *WebSocketConnection) Write(p []byte) (int, error) {
+	err := w.conn.WriteMessage(websocket.BinaryMessage, p)
+	if err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (w *WebSocketConnection) Close() error {
+	return w.conn.Close()
+}
+
+// OpenSerialConnection opens a serial port connection
+func OpenSerialConnection(portName string, baudRate int) (ByteReader, error) {
+	mode := &serial.Mode{
+		BaudRate: baudRate,
+		DataBits: 8,
+		Parity:   serial.NoParity,
+		StopBits: serial.OneStopBit,
+	}
+
+	port, err := serial.Open(portName, mode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open serial port %s: %v", portName, err)
+	}
+
+	return &SerialConnection{port: port}, nil
+}
+
+// OpenWebSocketConnection opens a WebSocket connection with HTTP Basic auth
+func OpenWebSocketConnection(wsURL, username, password string, skipSSLVerify bool) (ByteReader, error) {
+	// Parse and validate URL
+	u, err := url.Parse(wsURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid URL: %v", err)
+	}
+
+	// Validate scheme
+	switch u.Scheme {
+	case "ws", "wss":
+		// OK
+	default:
+		return nil, fmt.Errorf("unsupported URL scheme: %s (use ws:// or wss://)", u.Scheme)
+	}
+
+	// Create dialer with timeout
+	dialer := websocket.Dialer{
+		HandshakeTimeout: 10 * time.Second,
+	}
+
+	// Configure TLS for wss://
+	if u.Scheme == "wss" {
+		dialer.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: skipSSLVerify,
+		}
+	}
+
+	// Build HTTP headers with Basic auth
+	headers := http.Header{}
+	if username != "" && password != "" {
+		credentials := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+		headers.Set("Authorization", "Basic "+credentials)
+	}
+
+	// Connect
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	conn, resp, err := dialer.DialContext(ctx, wsURL, headers)
+	if err != nil {
+		if resp != nil {
+			return nil, fmt.Errorf("WebSocket connection failed (HTTP %d): %v", resp.StatusCode, err)
+		}
+		return nil, fmt.Errorf("WebSocket connection failed: %v", err)
+	}
+
+	return &WebSocketConnection{conn: conn}, nil
+}
+
+// GetPassword retrieves password from environment or prompts user
+func GetPassword() (string, error) {
+	// First check environment variable
+	if pw := os.Getenv("FUSAIN_PASSWORD"); pw != "" {
+		return pw, nil
+	}
+
+	// Prompt user for password (hide input)
+	fmt.Fprint(os.Stderr, "Password: ")
+
+	// Read password without echo
+	passwordBytes, err := term.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		// Fallback to regular input if terminal functions fail
+		reader := bufio.NewReader(os.Stdin)
+		password, err := reader.ReadString('\n')
+		if err != nil {
+			return "", fmt.Errorf("failed to read password: %v", err)
+		}
+		fmt.Fprintln(os.Stderr) // newline after password
+		return strings.TrimSpace(password), nil
+	}
+
+	fmt.Fprintln(os.Stderr) // newline after password
+	return string(passwordBytes), nil
+}
+
+// OpenConnection opens either a serial or WebSocket connection based on flags
+func OpenConnection() (ByteReader, string, error) {
+	if wsURL != "" {
+		// WebSocket mode
+		password := ""
+		if wsUsername != "" {
+			var err error
+			password, err = GetPassword()
+			if err != nil {
+				return nil, "", err
+			}
+		}
+
+		conn, err := OpenWebSocketConnection(wsURL, wsUsername, password, wsNoSSLVerify)
+		if err != nil {
+			return nil, "", err
+		}
+
+		return conn, fmt.Sprintf("WebSocket: %s", wsURL), nil
+	}
+
+	if portName != "" {
+		// Serial mode
+		conn, err := OpenSerialConnection(portName, baudRate)
+		if err != nil {
+			return nil, "", err
+		}
+
+		return conn, fmt.Sprintf("Serial: %s @ %d baud", portName, baudRate), nil
+	}
+
+	return nil, "", fmt.Errorf("either --port or --url must be specified")
+}

--- a/cmd/control.go
+++ b/cmd/control.go
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Kaz Walker, Thermoquad
+
+package cmd
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Thermoquad/heliostat/pkg/fusain"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/spf13/cobra"
+)
+
+var controlCmd = &cobra.Command{
+	Use:   "control",
+	Short: "Interactive TUI for controlling Helios heaters",
+	Long: `Control Helios heaters via an interactive terminal UI.
+
+This command provides a TUI for monitoring and controlling Helios devices
+connected via WebSocket (through Slate) or UART (direct connection).
+
+Features:
+  - Device discovery (DEVICE_ANNOUNCE)
+  - Real-time telemetry display
+  - State control (idle, fan mode)
+  - Statistics tracking
+  - Event logging
+  - Automatic reconnection on connection loss
+
+The TUI discovers devices first before enabling control. Tab switches between
+device list and control panel. Arrow keys navigate the device list.
+
+Supports both serial and WebSocket connections.`,
+	RunE: runControl,
+}
+
+func init() {
+	rootCmd.AddCommand(controlCmd)
+}
+
+// connectionManager handles connection lifecycle and reconnection
+type connectionManager struct {
+	conn     Connection
+	connInfo string
+	mu       sync.RWMutex
+	p        *tea.Program
+	done     chan struct{}
+	stopRead chan struct{}
+}
+
+func (cm *connectionManager) getConn() Connection {
+	cm.mu.RLock()
+	defer cm.mu.RUnlock()
+	return cm.conn
+}
+
+func (cm *connectionManager) setConn(conn Connection, connInfo string) {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+	cm.conn = conn
+	cm.connInfo = connInfo
+}
+
+func runControl(cmd *cobra.Command, args []string) error {
+	// Open initial connection (serial or WebSocket)
+	conn, connInfo, err := OpenConnection()
+	if err != nil {
+		return err
+	}
+
+	// Create connection manager
+	cm := &connectionManager{
+		conn:     conn,
+		connInfo: connInfo,
+		done:     make(chan struct{}),
+		stopRead: make(chan struct{}),
+	}
+
+	// Create TUI model with connection manager
+	m := initialControlModel(cm, connInfo)
+
+	// Create TUI program with alt screen and mouse support
+	p := tea.NewProgram(m, tea.WithAltScreen(), tea.WithMouseCellMotion())
+	cm.p = p
+
+	// Start reader goroutines (similar to error_detection.go pattern)
+	go cm.readerLoop()
+
+	// Send initial discovery request
+	sendInitialDiscoveryRequest(cm.getConn())
+
+	// Run TUI
+	if _, err := p.Run(); err != nil {
+		close(cm.done) // Signal goroutines to stop
+		cm.getConn().Close()
+		return fmt.Errorf("TUI error: %v", err)
+	}
+
+	close(cm.done) // Signal goroutines to stop
+	cm.getConn().Close()
+	return nil
+}
+
+// readerLoop handles reading from connection with automatic reconnection
+func (cm *connectionManager) readerLoop() {
+	for {
+		select {
+		case <-cm.done:
+			return
+		default:
+		}
+
+		// Start reading from current connection
+		connLost := cm.readFromConnection()
+
+		if connLost {
+			// Notify TUI about connection loss
+			cm.p.Send(connectionLostMsg{})
+
+			// Attempt to reconnect
+			if !cm.reconnect() {
+				return // Shutdown requested during reconnect
+			}
+		}
+	}
+}
+
+// readFromConnection reads packets from the connection until it fails
+// Returns true if connection was lost, false if shutdown requested
+func (cm *connectionManager) readFromConnection() bool {
+	decoder := fusain.NewDecoder()
+	synchronized := false
+	invalidBytesBeforeSync := 0
+
+	// Buffered channel for batching updates
+	batchChan := make(chan controlDataMsg, 100)
+	syncChan := make(chan controlSyncMsg, 1)
+	readerDone := make(chan struct{})
+
+	// Reader goroutine - decodes packets and sends to batch channel
+	go func() {
+		defer close(readerDone)
+		buf := make([]byte, 128)
+		for {
+			select {
+			case <-cm.done:
+				return
+			case <-cm.stopRead:
+				return
+			default:
+			}
+
+			conn := cm.getConn()
+			if conn == nil {
+				return
+			}
+
+			n, err := conn.Read(buf)
+			if err != nil {
+				// Check if we're shutting down
+				select {
+				case <-cm.done:
+					return
+				default:
+					// For WebSocket connections, a read error usually means
+					// the connection is permanently closed
+					if err == ErrConnectionClosed {
+						return
+					}
+					// Brief pause before retry on transient errors (e.g., serial)
+					time.Sleep(10 * time.Millisecond)
+					continue
+				}
+			}
+
+			for i := 0; i < n; i++ {
+				packet, decodeErr := decoder.DecodeByte(buf[i])
+
+				if decodeErr != nil {
+					if synchronized {
+						select {
+						case batchChan <- controlDataMsg{
+							packet:           nil,
+							decodeErr:        decodeErr,
+							validationErrors: nil,
+						}:
+						default:
+						}
+					} else {
+						invalidBytesBeforeSync++
+					}
+				} else if packet != nil {
+					if !synchronized {
+						synchronized = true
+						select {
+						case syncChan <- controlSyncMsg{invalidBytes: invalidBytesBeforeSync}:
+						default:
+						}
+					}
+
+					validationErrors := fusain.ValidatePacket(packet)
+					select {
+					case batchChan <- controlDataMsg{
+						packet:           packet,
+						decodeErr:        nil,
+						validationErrors: validationErrors,
+					}:
+					default:
+					}
+				}
+			}
+		}
+	}()
+
+	// Batch sender goroutine - sends batched updates to TUI at fixed rate
+	go func() {
+		ticker := time.NewTicker(50 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-cm.done:
+				return
+			case <-readerDone:
+				return
+			case <-ticker.C:
+				var batch controlBatchMsg
+
+				// Check for sync message
+				select {
+				case sync := <-syncChan:
+					batch.syncMsg = &sync
+				default:
+				}
+
+				// Drain all available messages from batch channel
+			drainLoop:
+				for {
+					select {
+					case msg := <-batchChan:
+						batch.messages = append(batch.messages, msg)
+					default:
+						break drainLoop
+					}
+				}
+
+				// Send batch if we have anything
+				if batch.syncMsg != nil || len(batch.messages) > 0 {
+					cm.p.Send(batch)
+				}
+			}
+		}
+	}()
+
+	// Wait for reader to finish (connection lost or shutdown)
+	<-readerDone
+
+	// Check if we're shutting down
+	select {
+	case <-cm.done:
+		return false
+	default:
+		return true // Connection lost
+	}
+}
+
+// reconnect attempts to reconnect with exponential backoff
+// Returns false if shutdown was requested during reconnection
+func (cm *connectionManager) reconnect() bool {
+	// Close old connection
+	if conn := cm.getConn(); conn != nil {
+		conn.Close()
+	}
+
+	backoff := 1 * time.Second
+	maxBackoff := 30 * time.Second
+
+	for {
+		select {
+		case <-cm.done:
+			return false
+		case <-time.After(backoff):
+		}
+
+		// Attempt to reconnect
+		conn, connInfo, err := OpenConnection()
+		if err == nil {
+			cm.setConn(conn, connInfo)
+
+			// Notify TUI about reconnection
+			cm.p.Send(reconnectedMsg{connInfo: connInfo})
+
+			// Send discovery request
+			sendInitialDiscoveryRequest(conn)
+
+			return true
+		}
+
+		// Exponential backoff
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// sendInitialDiscoveryRequest sends a discovery request to find devices
+func sendInitialDiscoveryRequest(conn Connection) {
+	packet := fusain.NewDiscoveryRequest(fusain.AddressBroadcast)
+	wireBytes := fusain.MustEncodePacket(packet)
+	conn.Write(wireBytes)
+}

--- a/cmd/control_tui.go
+++ b/cmd/control_tui.go
@@ -1,0 +1,1051 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Kaz Walker, Thermoquad
+
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Thermoquad/heliostat/pkg/fusain"
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+//////////////////////////////////////////////////////////////
+// Constants
+//////////////////////////////////////////////////////////////
+
+const (
+	discoveryTimeoutSeconds = 3 // Discovery ends N seconds after last device seen
+	pingIntervalSeconds     = 5 // Send ping requests every N seconds
+	maxRPM                  = 6000
+	minRPM                  = 0
+)
+
+// Focus states
+const (
+	focusDeviceList = iota
+	focusRPMInput
+	focusButton
+)
+
+//////////////////////////////////////////////////////////////
+// Types
+//////////////////////////////////////////////////////////////
+
+// device represents a discovered Helios heater
+type device struct {
+	address   uint64
+	state     uint64
+	stateName string
+	lastSeen  time.Time
+}
+
+// Implement list.Item interface
+func (d device) Title() string       { return fmt.Sprintf("Heater %016X", d.address) }
+func (d device) Description() string { return d.stateName }
+func (d device) FilterValue() string { return fmt.Sprintf("%X", d.address) }
+
+// controlModel is the Bubble Tea model for the control TUI
+type controlModel struct {
+	// Connection manager (for sending commands and reconnection)
+	connMgr  *connectionManager
+	connInfo string
+
+	// Device tracking
+	devices    []device
+	deviceList list.Model
+
+	// Discovery state
+	discoveryDone    bool
+	lastDeviceSeen   time.Time
+	discoveryDevices map[uint64]*device // Track devices during discovery
+
+	// Monitoring (reused from tui.go patterns)
+	stats         *fusain.Statistics
+	errorLog      []errorLogEntry
+	maxLogEntries int
+	lastTelemetry map[uint64]*telemetryData // Telemetry per device address
+
+	// Control
+	rpmInput     textinput.Model
+	focusedField int
+
+	// UI state
+	width          int
+	height         int
+	synchronized   bool
+	quitting       bool
+	connectionLost bool
+
+	// Ping state
+	lastPingTime    time.Time
+	routerUptime    uint64 // Router uptime from stateless address ping responses
+	hasRouterUptime bool
+}
+
+//////////////////////////////////////////////////////////////
+// Messages
+//////////////////////////////////////////////////////////////
+
+type controlTickMsg time.Time
+
+type controlDataMsg struct {
+	packet           *fusain.Packet
+	decodeErr        error
+	validationErrors []fusain.ValidationError
+}
+
+type controlSyncMsg struct {
+	invalidBytes int
+}
+
+type controlBatchMsg struct {
+	messages []controlDataMsg
+	syncMsg  *controlSyncMsg
+}
+
+type discoveryCompleteMsg struct{}
+
+type connectionLostMsg struct{}
+
+type reconnectedMsg struct {
+	connInfo string
+}
+
+//////////////////////////////////////////////////////////////
+// Model Initialization
+//////////////////////////////////////////////////////////////
+
+func initialControlModel(connMgr *connectionManager, connInfo string) controlModel {
+	// Initialize text input for RPM
+	ti := textinput.New()
+	ti.Placeholder = "1500"
+	ti.CharLimit = 5
+	ti.Width = 10
+
+	// Initialize device list with empty items
+	delegate := list.NewDefaultDelegate()
+	delegate.ShowDescription = true
+	delegate.SetHeight(2)
+	deviceList := list.New([]list.Item{}, delegate, 30, 10)
+	deviceList.Title = "Devices"
+	deviceList.SetShowStatusBar(false)
+	deviceList.SetShowHelp(false)
+	deviceList.SetFilteringEnabled(false)
+
+	return controlModel{
+		connMgr:          connMgr,
+		connInfo:         connInfo,
+		devices:          make([]device, 0),
+		deviceList:       deviceList,
+		discoveryDone:    false,
+		discoveryDevices: make(map[uint64]*device),
+		stats:            fusain.NewStatistics(),
+		errorLog:         make([]errorLogEntry, 0),
+		maxLogEntries:    100,
+		lastTelemetry:    make(map[uint64]*telemetryData),
+		rpmInput:         ti,
+		focusedField:     focusDeviceList,
+		width:            80,
+		height:           24,
+		synchronized:     false,
+	}
+}
+
+//////////////////////////////////////////////////////////////
+// Bubble Tea Interface
+//////////////////////////////////////////////////////////////
+
+func (m controlModel) Init() tea.Cmd {
+	return controlTickCmd()
+}
+
+func controlTickCmd() tea.Cmd {
+	return tea.Tick(time.Second, func(t time.Time) tea.Msg {
+		return controlTickMsg(t)
+	})
+}
+
+func (m controlModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		return m.handleKeyMsg(msg)
+
+	case tea.MouseMsg:
+		return m.handleMouseMsg(msg)
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		m.updateListSize()
+
+	case controlTickMsg:
+		m.stats.CalculateRates()
+		// Check discovery timeout
+		if !m.discoveryDone && !m.lastDeviceSeen.IsZero() {
+			if time.Since(m.lastDeviceSeen) > time.Duration(discoveryTimeoutSeconds)*time.Second {
+				m.finishDiscovery()
+			}
+		}
+		// Send periodic ping requests (after discovery)
+		// - To each device: gets device uptime (works in UART mode)
+		// - To stateless: keeps router subscription alive, gets router uptime
+		if m.discoveryDone && time.Since(m.lastPingTime) >= time.Duration(pingIntervalSeconds)*time.Second {
+			m.lastPingTime = time.Now()
+			for _, dev := range m.devices {
+				m.sendPingRequest(dev.address)
+			}
+			m.sendPingRequest(fusain.AddressStateless)
+		}
+		return m, controlTickCmd()
+
+	case controlSyncMsg:
+		m.synchronized = true
+		if msg.invalidBytes > 0 {
+			m.addLogEntry(fmt.Sprintf("Synchronized after skipping %d invalid bytes", msg.invalidBytes), false)
+		} else {
+			m.addLogEntry("Synchronized", false)
+		}
+
+	case controlBatchMsg:
+		if msg.syncMsg != nil {
+			m.synchronized = true
+			if msg.syncMsg.invalidBytes > 0 {
+				m.addLogEntry(fmt.Sprintf("Synchronized after skipping %d invalid bytes", msg.syncMsg.invalidBytes), false)
+			} else {
+				m.addLogEntry("Synchronized", false)
+			}
+		}
+		for _, data := range msg.messages {
+			m.processControlData(data)
+		}
+
+	case discoveryCompleteMsg:
+		m.finishDiscovery()
+
+	case connectionLostMsg:
+		m.connectionLost = true
+		m.addLogEntry("Connection lost - reconnecting...", true)
+
+	case reconnectedMsg:
+		m.connectionLost = false
+		m.connInfo = msg.connInfo
+		// Reset discovery state for new discovery cycle
+		m.resetDiscovery()
+		m.addLogEntry("Reconnected - starting discovery", false)
+	}
+
+	// Update child components
+	var cmd tea.Cmd
+	if m.focusedField == focusRPMInput {
+		m.rpmInput, cmd = m.rpmInput.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+
+	if m.focusedField == focusDeviceList {
+		m.deviceList, cmd = m.deviceList.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
+func (m *controlModel) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+
+	case "tab":
+		return m.cycleFocus(1), nil
+
+	case "shift+tab":
+		return m.cycleFocus(-1), nil
+
+	case "enter":
+		if m.discoveryDone {
+			return m.handleEnter()
+		}
+
+	case "up", "k":
+		if m.focusedField == focusDeviceList {
+			m.deviceList, _ = m.deviceList.Update(msg)
+		}
+
+	case "down", "j":
+		if m.focusedField == focusDeviceList {
+			m.deviceList, _ = m.deviceList.Update(msg)
+		}
+	}
+
+	// Pass through to focused component
+	if m.focusedField == focusRPMInput {
+		var cmd tea.Cmd
+		m.rpmInput, cmd = m.rpmInput.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
+}
+
+func (m *controlModel) handleMouseMsg(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	if msg.Action != tea.MouseActionRelease || msg.Button != tea.MouseButtonLeft {
+		return m, nil
+	}
+
+	// Handle mouse clicks based on position
+	// Device list is in left panel (columns 0-30)
+	// Control panel is on right
+	// Button detection is approximate based on layout
+
+	// For now, pass mouse events to the list
+	m.deviceList, _ = m.deviceList.Update(msg)
+
+	return m, nil
+}
+
+func (m *controlModel) cycleFocus(delta int) *controlModel {
+	if !m.discoveryDone {
+		return m
+	}
+
+	// Determine max focus based on state
+	maxFocus := focusButton
+	selected := m.getSelectedDevice()
+	if selected == nil {
+		m.focusedField = focusDeviceList
+		return m
+	}
+
+	// Cycle through focus states
+	m.focusedField = (m.focusedField + delta + maxFocus + 1) % (maxFocus + 1)
+
+	// Skip RPM input if not in IDLE state
+	if m.focusedField == focusRPMInput && selected.state != uint64(fusain.SysStateIdle) {
+		m.focusedField = (m.focusedField + delta + maxFocus + 1) % (maxFocus + 1)
+	}
+
+	// Update focus state
+	if m.focusedField == focusRPMInput {
+		m.rpmInput.Focus()
+	} else {
+		m.rpmInput.Blur()
+	}
+
+	return m
+}
+
+func (m *controlModel) handleEnter() (tea.Model, tea.Cmd) {
+	// Don't allow control commands while connection is lost
+	if m.connectionLost {
+		m.addLogEntry("Cannot send command: connection lost", true)
+		return m, nil
+	}
+
+	selected := m.getSelectedDevice()
+	if selected == nil {
+		return m, nil
+	}
+
+	// In IDLE state: Start Fan button or RPM input triggers fan command
+	if selected.state == uint64(fusain.SysStateIdle) {
+		if m.focusedField == focusButton || m.focusedField == focusRPMInput {
+			return m.sendFanCommand()
+		}
+	}
+
+	// In FAN/BLOWING state: Return to Idle button
+	if selected.state == uint64(fusain.SysStateBlowing) {
+		if m.focusedField == focusButton {
+			return m.sendIdleCommand()
+		}
+	}
+
+	return m, nil
+}
+
+func (m controlModel) View() string {
+	if m.quitting {
+		return "Shutting down...\n"
+	}
+
+	var s strings.Builder
+
+	// Styles
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("12")).
+		Background(lipgloss.Color("235")).
+		Padding(0, 1)
+
+	headerStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("241"))
+
+	statsLabelStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("12")).
+		Bold(true)
+
+	statsValueStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("10"))
+
+	errorStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("9")).
+		Bold(true)
+
+	warningStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("11"))
+
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(0, 1)
+
+	focusedBoxStyle := boxStyle.
+		BorderForeground(lipgloss.Color("12"))
+
+	buttonStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("0")).
+		Background(lipgloss.Color("12")).
+		Padding(0, 2)
+
+	focusedButtonStyle := buttonStyle.
+		Background(lipgloss.Color("10"))
+
+	// Header
+	helpText := "q=quit"
+	if m.discoveryDone {
+		helpText = "q=quit Tab=switch"
+	}
+	s.WriteString(titleStyle.Render("HELIOSTAT CONTROL"))
+	s.WriteString(" ")
+	connStatus := m.connInfo
+	if m.connectionLost {
+		connStatus = warningStyle.Render("RECONNECTING...")
+	}
+	s.WriteString(headerStyle.Render(fmt.Sprintf("| %s | %s", connStatus, helpText)))
+	s.WriteString("\n")
+
+	// Router uptime (below header)
+	if m.hasRouterUptime {
+		s.WriteString(fmt.Sprintf(" %s %s",
+			statsLabelStyle.Render("Router Uptime:"),
+			statsValueStyle.Render(formatUptime(m.routerUptime))))
+	}
+	s.WriteString("\n\n")
+
+	if !m.discoveryDone {
+		// Discovery mode view
+		s.WriteString(m.renderDiscoveryView(statsLabelStyle, statsValueStyle, warningStyle, boxStyle))
+	} else {
+		// Normal control view
+		s.WriteString(m.renderControlView(statsLabelStyle, statsValueStyle, errorStyle, warningStyle, headerStyle, boxStyle, focusedBoxStyle, buttonStyle, focusedButtonStyle))
+	}
+
+	return s.String()
+}
+
+//////////////////////////////////////////////////////////////
+// View Helpers
+//////////////////////////////////////////////////////////////
+
+func (m controlModel) renderDiscoveryView(statsLabelStyle, statsValueStyle, warningStyle, boxStyle lipgloss.Style) string {
+	var s strings.Builder
+
+	s.WriteString(warningStyle.Render("Discovering devices..."))
+	s.WriteString("\n")
+	s.WriteString(fmt.Sprintf("Found: %d heater(s)\n\n", len(m.discoveryDevices)))
+
+	// Event log during discovery
+	s.WriteString(m.renderEventLog(statsLabelStyle, warningStyle, boxStyle))
+
+	return s.String()
+}
+
+func (m controlModel) renderControlView(statsLabelStyle, statsValueStyle, errorStyle, warningStyle, headerStyle, boxStyle, focusedBoxStyle, buttonStyle, focusedButtonStyle lipgloss.Style) string {
+	var s strings.Builder
+
+	// Layout: left panel (devices) | right panel (control)
+	leftWidth := 30
+	rightWidth := m.width - leftWidth - 6
+
+	// Device list panel
+	listStyle := boxStyle.Width(leftWidth)
+	if m.focusedField == focusDeviceList {
+		listStyle = focusedBoxStyle.Width(leftWidth)
+	}
+	devicePanel := listStyle.Render(m.deviceList.View())
+
+	// Control panel
+	controlContent := m.renderControlPanel(statsLabelStyle, statsValueStyle, headerStyle, buttonStyle, focusedButtonStyle)
+	controlStyle := boxStyle.Width(rightWidth)
+	controlPanel := controlStyle.Render(controlContent)
+
+	// Join panels horizontally
+	s.WriteString(lipgloss.JoinHorizontal(lipgloss.Top, devicePanel, " ", controlPanel))
+	s.WriteString("\n\n")
+
+	// Statistics bar
+	s.WriteString(m.renderStatisticsBar(statsLabelStyle, statsValueStyle, errorStyle, boxStyle))
+	s.WriteString("\n\n")
+
+	// Telemetry for selected device
+	selected := m.getSelectedDevice()
+	if selected != nil {
+		s.WriteString(m.renderTelemetry(selected.address, statsLabelStyle, statsValueStyle, boxStyle))
+		s.WriteString("\n\n")
+	}
+
+	// Event log
+	s.WriteString(m.renderEventLog(statsLabelStyle, warningStyle, boxStyle))
+
+	return s.String()
+}
+
+func (m controlModel) renderControlPanel(statsLabelStyle, statsValueStyle, headerStyle, buttonStyle, focusedButtonStyle lipgloss.Style) string {
+	var s strings.Builder
+
+	selected := m.getSelectedDevice()
+	if selected == nil {
+		s.WriteString(headerStyle.Render("No device selected"))
+		return s.String()
+	}
+
+	// Selected device info
+	s.WriteString(fmt.Sprintf("%s Heater %016X\n", statsLabelStyle.Render("Selected:"), selected.address))
+	s.WriteString(fmt.Sprintf("%s %s\n\n", statsLabelStyle.Render("State:"), statsValueStyle.Render(selected.stateName)))
+
+	// Control based on state
+	if selected.state == uint64(fusain.SysStateIdle) {
+		// IDLE state: show fan RPM input and Start Fan button
+		s.WriteString(statsLabelStyle.Render("Fan RPM: "))
+		if m.focusedField == focusRPMInput {
+			s.WriteString(m.rpmInput.View())
+		} else {
+			// Show as plain text when not focused
+			val := m.rpmInput.Value()
+			if val == "" {
+				val = m.rpmInput.Placeholder
+			}
+			s.WriteString(fmt.Sprintf("[%s]", val))
+		}
+		s.WriteString("\n\n")
+
+		// Start Fan button
+		btnText := "[ Start Fan ]"
+		if m.focusedField == focusButton {
+			s.WriteString(focusedButtonStyle.Render(btnText))
+		} else {
+			s.WriteString(buttonStyle.Render(btnText))
+		}
+	} else if selected.state == uint64(fusain.SysStateBlowing) {
+		// FAN/BLOWING state: show current RPM and Return to Idle button
+		telem := m.lastTelemetry[selected.address]
+		if telem != nil && len(telem.motorRPM) > 0 {
+			s.WriteString(fmt.Sprintf("Current: %s / %d target\n\n",
+				statsValueStyle.Render(fmt.Sprintf("%d RPM", telem.motorRPM[0])),
+				telem.motorTarget[0]))
+		}
+
+		// Return to Idle button
+		btnText := "[ Return to Idle ]"
+		if m.focusedField == focusButton {
+			s.WriteString(focusedButtonStyle.Render(btnText))
+		} else {
+			s.WriteString(buttonStyle.Render(btnText))
+		}
+	} else {
+		// Other states: just show state name
+		s.WriteString(headerStyle.Render(fmt.Sprintf("State: %s (no controls available)", selected.stateName)))
+	}
+
+	return s.String()
+}
+
+func (m controlModel) renderStatisticsBar(statsLabelStyle, statsValueStyle, errorStyle, boxStyle lipgloss.Style) string {
+	m.stats.CalculateRates()
+	var validPercent, errorPercent float64
+	if m.stats.TotalPackets > 0 {
+		validPercent = float64(m.stats.ValidPackets) * 100.0 / float64(m.stats.TotalPackets)
+		totalErrors := m.stats.CRCErrors + m.stats.DecodeErrors + m.stats.MalformedPackets + m.stats.AnomalousValues
+		errorPercent = float64(totalErrors) * 100.0 / float64(m.stats.TotalPackets)
+	}
+
+	content := fmt.Sprintf("%s %s  %s %s  %s %s  %s %s",
+		statsLabelStyle.Render("Total:"), statsValueStyle.Render(fmt.Sprintf("%d", m.stats.TotalPackets)),
+		statsLabelStyle.Render("Valid:"), statsValueStyle.Render(fmt.Sprintf("%.1f%%", validPercent)),
+		statsLabelStyle.Render("Errors:"), func() string {
+			if errorPercent > 0 {
+				return errorStyle.Render(fmt.Sprintf("%.1f%%", errorPercent))
+			}
+			return statsValueStyle.Render("0.0%")
+		}(),
+		statsLabelStyle.Render("Rate:"), statsValueStyle.Render(fmt.Sprintf("%.1f pkt/s", m.stats.PacketRate)),
+	)
+
+	return boxStyle.Width(m.width - 4).Render(content)
+}
+
+func (m controlModel) renderTelemetry(address uint64, statsLabelStyle, statsValueStyle, boxStyle lipgloss.Style) string {
+	telem := m.lastTelemetry[address]
+
+	var content strings.Builder
+	content.WriteString(statsLabelStyle.Render("TELEMETRY"))
+	content.WriteString(" | ")
+
+	if telem == nil {
+		content.WriteString("No telemetry data")
+		return boxStyle.Width(m.width - 4).Render(content.String())
+	}
+
+	// State
+	content.WriteString(fmt.Sprintf("%s %s  ", statsLabelStyle.Render("State:"), statsValueStyle.Render(telem.stateName)))
+
+	// Motor
+	if len(telem.motorRPM) > 0 {
+		content.WriteString(fmt.Sprintf("%s %s  ",
+			statsLabelStyle.Render("Motor:"),
+			statsValueStyle.Render(fmt.Sprintf("%d RPM", telem.motorRPM[0]))))
+	}
+
+	// Temperature
+	if len(telem.temperatures) > 0 {
+		content.WriteString(fmt.Sprintf("%s %s  ",
+			statsLabelStyle.Render("Temp:"),
+			statsValueStyle.Render(fmt.Sprintf("%.1fC", telem.temperatures[0]))))
+	}
+
+	// Device uptime (from device-addressed ping response)
+	if telem.hasUptime {
+		content.WriteString(fmt.Sprintf("%s %s",
+			statsLabelStyle.Render("Uptime:"),
+			statsValueStyle.Render(formatUptime(telem.uptime))))
+	}
+
+	return boxStyle.Width(m.width - 4).Render(content.String())
+}
+
+func (m controlModel) renderEventLog(statsLabelStyle, warningStyle, boxStyle lipgloss.Style) string {
+	var s strings.Builder
+	s.WriteString(statsLabelStyle.Render("EVENTS"))
+	s.WriteString("\n")
+
+	headerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	errorStyleLocal := lipgloss.NewStyle().Foreground(lipgloss.Color("9")).Bold(true)
+
+	// Calculate available height for log
+	logHeight := 8
+	if len(m.errorLog) < logHeight {
+		logHeight = len(m.errorLog)
+	}
+
+	startIdx := len(m.errorLog) - logHeight
+	if startIdx < 0 {
+		startIdx = 0
+	}
+
+	if len(m.errorLog) == 0 {
+		s.WriteString(headerStyle.Render("  (no events yet)"))
+	} else {
+		for i := startIdx; i < len(m.errorLog); i++ {
+			entry := m.errorLog[i]
+			timestamp := entry.timestamp.Format("15:04:05.000")
+			icon := "i"
+			style := warningStyle
+			if entry.isError {
+				icon = "x"
+				style = errorStyleLocal
+			}
+			s.WriteString(fmt.Sprintf("%s %s %s\n",
+				headerStyle.Render(timestamp),
+				style.Render(icon),
+				entry.message))
+		}
+	}
+
+	return boxStyle.Width(m.width - 4).Render(s.String())
+}
+
+//////////////////////////////////////////////////////////////
+// Data Processing
+//////////////////////////////////////////////////////////////
+
+func (m *controlModel) processControlData(msg controlDataMsg) {
+	if msg.decodeErr != nil {
+		if m.synchronized {
+			m.stats.Update(nil, msg.decodeErr, nil)
+			m.addLogEntry(fmt.Sprintf("DECODE ERROR: %v", msg.decodeErr), true)
+		}
+		return
+	}
+
+	if msg.packet == nil {
+		return
+	}
+
+	m.stats.Update(msg.packet, nil, msg.validationErrors)
+
+	// Process packet based on type
+	msgType := msg.packet.Type()
+	address := msg.packet.Address()
+
+	switch msgType {
+	case fusain.MsgDeviceAnnounce:
+		m.handleDeviceAnnounce(msg.packet)
+
+	case fusain.MsgStateData:
+		m.handleStateData(msg.packet, address)
+		// Also parse telemetry
+		m.parseTelemetryForDevice(msg.packet, address)
+
+	case fusain.MsgMotorData, fusain.MsgTempData:
+		m.parseTelemetryForDevice(msg.packet, address)
+
+	case fusain.MsgPingResponse:
+		// If from stateless address (router), update router uptime only
+		// If from specific device, update that device's uptime
+		if address == fusain.AddressStateless {
+			// Router uptime - store separately, don't update device uptimes
+			payloadMap := msg.packet.PayloadMap()
+			uptime, ok := fusain.GetMapUint(payloadMap, 0)
+			if ok {
+				m.routerUptime = uptime
+				m.hasRouterUptime = true
+			}
+		} else {
+			// Device-specific uptime
+			m.parseTelemetryForDevice(msg.packet, address)
+		}
+
+	default:
+		// Other packet types - just log if there are validation errors
+		if len(msg.validationErrors) > 0 {
+			for _, err := range msg.validationErrors {
+				m.addLogEntry(fmt.Sprintf("%s: %s", fusain.FormatMessageType(msgType), err.Message), true)
+			}
+		}
+	}
+}
+
+func (m *controlModel) handleDeviceAnnounce(packet *fusain.Packet) {
+	address := packet.Address()
+
+	// Check for end-of-discovery marker:
+	// Per Fusain spec: ADDRESS = stateless (0xFFFFFFFFFFFFFFFF), all counts = 0
+	if address == fusain.AddressStateless {
+		if !m.discoveryDone {
+			m.finishDiscovery()
+		}
+		return
+	}
+
+	// Add/update device in discovery map
+	if _, exists := m.discoveryDevices[address]; !exists {
+		m.discoveryDevices[address] = &device{
+			address:   address,
+			state:     uint64(fusain.SysStateIdle),
+			stateName: "IDLE",
+			lastSeen:  time.Now(),
+		}
+		m.addLogEntry(fmt.Sprintf("Device discovered: %016X", address), false)
+	}
+	m.lastDeviceSeen = time.Now()
+}
+
+func (m *controlModel) handleStateData(packet *fusain.Packet, address uint64) {
+	payloadMap := packet.PayloadMap()
+	stateNames := []string{"INITIALIZING", "IDLE", "BLOWING", "PREHEAT", "PREHEAT_STAGE_2", "HEATING", "COOLING", "ERROR", "E_STOP"}
+
+	state, hasState := fusain.GetMapUint(payloadMap, 2)
+	if !hasState {
+		return
+	}
+
+	stateName := "UNKNOWN"
+	if int(state) < len(stateNames) {
+		stateName = stateNames[state]
+	}
+
+	// Update device state
+	if m.discoveryDone {
+		for i := range m.devices {
+			if m.devices[i].address == address {
+				oldState := m.devices[i].stateName
+				m.devices[i].state = state
+				m.devices[i].stateName = stateName
+				m.devices[i].lastSeen = time.Now()
+
+				// Log state change
+				if oldState != stateName {
+					m.addLogEntry(fmt.Sprintf("Device %016X: %s -> %s", address, oldState, stateName), false)
+				}
+
+				// Update list
+				m.updateDeviceList()
+				break
+			}
+		}
+	} else {
+		// During discovery, update the discovery device
+		if dev, exists := m.discoveryDevices[address]; exists {
+			dev.state = state
+			dev.stateName = stateName
+			dev.lastSeen = time.Now()
+		}
+		m.lastDeviceSeen = time.Now()
+	}
+}
+
+func (m *controlModel) parseTelemetryForDevice(packet *fusain.Packet, address uint64) {
+	payloadMap := packet.PayloadMap()
+	stateNames := []string{"INITIALIZING", "IDLE", "BLOWING", "PREHEAT", "PREHEAT_STAGE_2", "HEATING", "COOLING", "ERROR", "E_STOP"}
+
+	// Ensure telemetry entry exists
+	if m.lastTelemetry[address] == nil {
+		m.lastTelemetry[address] = &telemetryData{timestamp: time.Now()}
+	}
+	telem := m.lastTelemetry[address]
+
+	switch packet.Type() {
+	case fusain.MsgStateData:
+		state, hasState := fusain.GetMapUint(payloadMap, 2)
+		if hasState {
+			telem.state = state
+			if int(state) < len(stateNames) {
+				telem.stateName = stateNames[state]
+			}
+		}
+		errorCode, _ := fusain.GetMapInt(payloadMap, 1)
+		telem.errorCode = errorCode
+		telem.timestamp = time.Now()
+
+	case fusain.MsgPingResponse:
+		uptime, ok := fusain.GetMapUint(payloadMap, 0)
+		if ok {
+			telem.uptime = uptime
+			telem.hasUptime = true
+		}
+
+	case fusain.MsgMotorData:
+		motorIdx, ok := fusain.GetMapInt(payloadMap, 0)
+		if !ok || motorIdx < 0 {
+			return
+		}
+		rpm, _ := fusain.GetMapInt(payloadMap, 2)
+		target, _ := fusain.GetMapInt(payloadMap, 3)
+
+		for len(telem.motorRPM) <= int(motorIdx) {
+			telem.motorRPM = append(telem.motorRPM, 0)
+		}
+		for len(telem.motorTarget) <= int(motorIdx) {
+			telem.motorTarget = append(telem.motorTarget, 0)
+		}
+		telem.motorRPM[motorIdx] = rpm
+		telem.motorTarget[motorIdx] = target
+
+	case fusain.MsgTempData:
+		tempIdx, ok := fusain.GetMapInt(payloadMap, 0)
+		if !ok || tempIdx < 0 {
+			return
+		}
+		reading, _ := fusain.GetMapFloat(payloadMap, 2)
+
+		for len(telem.temperatures) <= int(tempIdx) {
+			telem.temperatures = append(telem.temperatures, 0)
+		}
+		telem.temperatures[tempIdx] = reading
+	}
+}
+
+//////////////////////////////////////////////////////////////
+// Commands
+//////////////////////////////////////////////////////////////
+
+func (m *controlModel) sendFanCommand() (tea.Model, tea.Cmd) {
+	selected := m.getSelectedDevice()
+	if selected == nil {
+		return m, nil
+	}
+
+	// Parse RPM from input
+	rpmStr := m.rpmInput.Value()
+	if rpmStr == "" {
+		rpmStr = m.rpmInput.Placeholder
+	}
+
+	rpm, err := strconv.ParseInt(rpmStr, 10, 64)
+	if err != nil {
+		m.addLogEntry(fmt.Sprintf("Invalid RPM value: %s", rpmStr), true)
+		return m, nil
+	}
+
+	if rpm < minRPM || rpm > maxRPM {
+		m.addLogEntry(fmt.Sprintf("RPM must be between %d and %d", minRPM, maxRPM), true)
+		return m, nil
+	}
+
+	// Send fan command
+	packet := fusain.NewStateCommand(selected.address, uint8(fusain.ModeFan), &rpm)
+	wireBytes := fusain.MustEncodePacket(packet)
+	conn := m.connMgr.getConn()
+	if conn == nil {
+		m.addLogEntry("Cannot send command: connection lost", true)
+		return m, nil
+	}
+	_, err = conn.Write(wireBytes)
+	if err != nil {
+		m.addLogEntry(fmt.Sprintf("Failed to send command: %v", err), true)
+		return m, nil
+	}
+
+	m.addLogEntry(fmt.Sprintf("Sent FAN command (RPM=%d) to %016X", rpm, selected.address), false)
+	return m, nil
+}
+
+func (m *controlModel) sendIdleCommand() (tea.Model, tea.Cmd) {
+	selected := m.getSelectedDevice()
+	if selected == nil {
+		return m, nil
+	}
+
+	// Send idle command
+	packet := fusain.NewStateCommand(selected.address, uint8(fusain.ModeIdle), nil)
+	wireBytes := fusain.MustEncodePacket(packet)
+	conn := m.connMgr.getConn()
+	if conn == nil {
+		m.addLogEntry("Cannot send command: connection lost", true)
+		return m, nil
+	}
+	_, err := conn.Write(wireBytes)
+	if err != nil {
+		m.addLogEntry(fmt.Sprintf("Failed to send command: %v", err), true)
+		return m, nil
+	}
+
+	m.addLogEntry(fmt.Sprintf("Sent IDLE command to %016X", selected.address), false)
+	return m, nil
+}
+
+//////////////////////////////////////////////////////////////
+// Helpers
+//////////////////////////////////////////////////////////////
+
+func (m *controlModel) addLogEntry(message string, isError bool) {
+	entry := errorLogEntry{
+		timestamp: time.Now(),
+		message:   message,
+		isError:   isError,
+	}
+	m.errorLog = append(m.errorLog, entry)
+
+	if len(m.errorLog) > m.maxLogEntries {
+		m.errorLog = m.errorLog[len(m.errorLog)-m.maxLogEntries:]
+	}
+}
+
+func (m *controlModel) getSelectedDevice() *device {
+	if len(m.devices) == 0 {
+		return nil
+	}
+
+	idx := m.deviceList.Index()
+	if idx < 0 || idx >= len(m.devices) {
+		return nil
+	}
+
+	return &m.devices[idx]
+}
+
+func (m *controlModel) finishDiscovery() {
+	if m.discoveryDone {
+		return
+	}
+
+	m.discoveryDone = true
+
+	// Convert discovery map to device slice
+	m.devices = make([]device, 0, len(m.discoveryDevices))
+	for _, dev := range m.discoveryDevices {
+		m.devices = append(m.devices, *dev)
+	}
+
+	// Update the list model
+	m.updateDeviceList()
+
+	m.addLogEntry(fmt.Sprintf("Discovery complete: %d heater(s)", len(m.devices)), false)
+
+	// Send telemetry subscription to each discovered device
+	for _, dev := range m.devices {
+		m.sendTelemetrySubscription(dev.address)
+	}
+
+	// Focus device list if we have devices
+	if len(m.devices) > 0 {
+		m.focusedField = focusDeviceList
+	}
+}
+
+func (m *controlModel) resetDiscovery() {
+	m.discoveryDone = false
+	m.discoveryDevices = make(map[uint64]*device)
+	m.devices = make([]device, 0)
+	m.lastDeviceSeen = time.Time{}
+	m.lastTelemetry = make(map[uint64]*telemetryData)
+	m.synchronized = false
+	m.updateDeviceList()
+}
+
+func (m *controlModel) sendTelemetrySubscription(address uint64) {
+	// Send DATA_SUBSCRIPTION to router (stateless address) to subscribe to this appliance
+	packet := fusain.NewDataSubscription(fusain.AddressStateless, address)
+	wireBytes := fusain.MustEncodePacket(packet)
+	conn := m.connMgr.getConn()
+	if conn == nil {
+		m.addLogEntry(fmt.Sprintf("Failed to subscribe to %016X: connection lost", address), true)
+		return
+	}
+	_, err := conn.Write(wireBytes)
+	if err != nil {
+		m.addLogEntry(fmt.Sprintf("Failed to subscribe to %016X: %v", address, err), true)
+		return
+	}
+	m.addLogEntry(fmt.Sprintf("Subscribed to telemetry: %016X", address), false)
+}
+
+func (m *controlModel) sendPingRequest(address uint64) {
+	// Send PING_REQUEST to device to get uptime
+	packet := fusain.NewPingRequest(address)
+	wireBytes := fusain.MustEncodePacket(packet)
+	conn := m.connMgr.getConn()
+	if conn == nil {
+		return // Silently fail - connection lost is handled elsewhere
+	}
+	_, err := conn.Write(wireBytes)
+	if err != nil {
+		return // Silently fail - next tick will retry
+	}
+}
+
+func (m *controlModel) updateDeviceList() {
+	items := make([]list.Item, len(m.devices))
+	for i, d := range m.devices {
+		items[i] = d
+	}
+	m.deviceList.SetItems(items)
+}
+
+func (m *controlModel) updateListSize() {
+	// Adjust list size based on terminal size
+	listHeight := m.height / 3
+	if listHeight < 5 {
+		listHeight = 5
+	}
+	m.deviceList.SetSize(28, listHeight)
+}

--- a/cmd/discovery.go
+++ b/cmd/discovery.go
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Kaz Walker, Thermoquad
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Thermoquad/heliostat/pkg/fusain"
+	"github.com/spf13/cobra"
+)
+
+var (
+	discoveryTimeout int
+	discoveryRouter  bool
+)
+
+var discoveryCmd = &cobra.Command{
+	Use:   "discovery",
+	Short: "Discover devices via serial or WebSocket",
+	Long: `Send DISCOVERY_REQUEST to discover Fusain devices.
+
+Modes:
+  Serial (default): Send broadcast DISCOVERY_REQUEST to discover appliances directly.
+                    Appliances respond with DEVICE_ANNOUNCE (0-50ms random delay).
+
+  Router (--router): Send stateless DISCOVERY_REQUEST to a router (e.g., Slate).
+                     Router responds with DEVICE_ANNOUNCE for each known device,
+                     followed by an end-of-discovery marker (all zeros).
+
+Per the Fusain spec:
+  - Appliances ignore non-broadcast DISCOVERY_REQUEST
+  - Routers respond to stateless address with known devices
+
+Examples:
+  # Direct serial discovery to Helios
+  heliostat discovery --port /dev/ttyUSB0
+
+  # WebSocket router discovery (Slate)
+  heliostat discovery --url ws://slate.local/fusain --router
+
+Exit codes:
+  0 - Discovery successful (at least one device found)
+  1 - Discovery failed (no devices or timeout)
+  2 - Connection error`,
+	RunE: runDiscovery,
+}
+
+func init() {
+	rootCmd.AddCommand(discoveryCmd)
+	discoveryCmd.Flags().IntVar(&discoveryTimeout, "timeout", 5, "Timeout in seconds for discovery")
+	discoveryCmd.Flags().BoolVar(&discoveryRouter, "router", false, "Use router mode (stateless address)")
+}
+
+func runDiscovery(cmd *cobra.Command, args []string) error {
+	// Open connection (serial or WebSocket)
+	conn, connInfo, err := OpenConnection()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Connection error: %v\n", err)
+		os.Exit(2)
+	}
+	defer conn.Close()
+
+	mode := "appliance"
+	var address uint64 = fusain.AddressBroadcast
+	if discoveryRouter {
+		mode = "router"
+		address = fusain.AddressStateless
+	}
+
+	fmt.Printf("Heliostat - Device Discovery\n")
+	fmt.Printf("Connection: %s\n", connInfo)
+	fmt.Printf("Mode: %s\n", mode)
+	fmt.Printf("Timeout: %d seconds\n\n", discoveryTimeout)
+
+	decoder := fusain.NewDecoder()
+
+	// Create DISCOVERY_REQUEST packet
+	discoveryPacket := fusain.NewDiscoveryRequest(address)
+	wireBytes := fusain.MustEncodePacket(discoveryPacket)
+
+	// Send discovery request
+	fmt.Printf("Sending DISCOVERY_REQUEST (address=0x%016X)...\n", address)
+	_, err = conn.Write(wireBytes)
+	if err != nil {
+		fmt.Printf("SEND FAILED: %v\n", err)
+		os.Exit(2)
+	}
+
+	// Collect DEVICE_ANNOUNCE responses
+	devices := make([]discoveryDeviceInfo, 0)
+	done := make(chan bool, 1)
+	errChan := make(chan error, 1)
+
+	go func() {
+		buf := make([]byte, 128)
+		for {
+			n, err := conn.Read(buf)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			for j := 0; j < n; j++ {
+				packet, decodeErr := decoder.DecodeByte(buf[j])
+				if decodeErr != nil {
+					continue
+				}
+				if packet != nil {
+					msgType := packet.Type()
+					if msgType == fusain.MsgDeviceAnnounce {
+						device := parseDiscoveryAnnounce(packet)
+
+						// End-of-discovery marker (router mode only)
+						if device.isEndMarker() {
+							if discoveryRouter {
+								fmt.Printf("\nEnd of discovery marker received\n")
+								done <- true
+								return
+							}
+							// Ignore zero-capability devices in appliance mode
+							continue
+						}
+
+						devices = append(devices, device)
+						fmt.Printf("\nDevice found:\n")
+						fmt.Printf("  Address: 0x%016X\n", device.address)
+						fmt.Printf("  Motors: %d\n", device.motorCount)
+						fmt.Printf("  Thermometers: %d\n", device.thermometerCount)
+						fmt.Printf("  Pumps: %d\n", device.pumpCount)
+						fmt.Printf("  Glow plugs: %d\n", device.glowCount)
+
+						// In appliance mode, we might get multiple devices
+						// but typically just one (Helios) on a point-to-point link
+						// Continue listening for more responses
+					}
+				}
+			}
+		}
+	}()
+
+	// Wait for discovery to complete or timeout
+	select {
+	case <-done:
+		// Discovery complete (router sent end marker)
+	case err := <-errChan:
+		fmt.Printf("READ FAILED: %v\n", err)
+		os.Exit(2)
+	case <-time.After(time.Duration(discoveryTimeout) * time.Second):
+		if discoveryRouter {
+			fmt.Printf("\nTIMEOUT: No end-of-discovery marker received in %ds\n", discoveryTimeout)
+		} else {
+			// In appliance mode, timeout is expected after all devices respond
+			if len(devices) > 0 {
+				fmt.Printf("\nDiscovery timeout reached\n")
+			} else {
+				fmt.Printf("\nTIMEOUT: No devices responded in %ds\n", discoveryTimeout)
+			}
+		}
+	}
+
+	// Summary
+	fmt.Printf("\n--- Discovery summary ---\n")
+	fmt.Printf("Devices found: %d\n", len(devices))
+
+	if len(devices) == 0 {
+		if discoveryRouter {
+			fmt.Printf("No devices discovered. Router may not have any connected devices.\n")
+		} else {
+			fmt.Printf("No devices discovered. Check connection and device power.\n")
+		}
+		os.Exit(1)
+	}
+
+	return nil
+}
+
+type discoveryDeviceInfo struct {
+	address          uint64
+	motorCount       uint64
+	thermometerCount uint64
+	pumpCount        uint64
+	glowCount        uint64
+}
+
+func (d discoveryDeviceInfo) isEndMarker() bool {
+	return d.motorCount == 0 && d.thermometerCount == 0 && d.pumpCount == 0 && d.glowCount == 0
+}
+
+func parseDiscoveryAnnounce(p *fusain.Packet) discoveryDeviceInfo {
+	payloadMap := p.PayloadMap()
+
+	motorCount, _ := fusain.GetMapUint(payloadMap, 0)
+	thermometerCount, _ := fusain.GetMapUint(payloadMap, 1)
+	pumpCount, _ := fusain.GetMapUint(payloadMap, 2)
+	glowCount, _ := fusain.GetMapUint(payloadMap, 3)
+
+	return discoveryDeviceInfo{
+		address:          p.Address(),
+		motorCount:       motorCount,
+		thermometerCount: thermometerCount,
+		pumpCount:        pumpCount,
+		glowCount:        glowCount,
+	}
+}

--- a/cmd/packettest.go
+++ b/cmd/packettest.go
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Kaz Walker, Thermoquad
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Thermoquad/heliostat/pkg/fusain"
+	"github.com/spf13/cobra"
+)
+
+var (
+	packetTestTimeout int
+)
+
+var packetTestCmd = &cobra.Command{
+	Use:   "packet_test",
+	Short: "Test connection by waiting for a valid Fusain packet",
+	Long: `Wait for a valid Fusain packet on the connection until timeout.
+
+This command connects to a serial port or WebSocket and waits for any valid
+Fusain protocol packet. It ignores invalid bytes and waits for a complete,
+valid packet (passing CRC check).
+
+Exit codes:
+  0 - Packet received before timeout
+  1 - Timeout reached without receiving a valid packet
+  2 - Connection error
+
+Useful for testing connectivity to Helios or Slate WebSocket bridge.`,
+	RunE: runPacketTest,
+}
+
+func init() {
+	rootCmd.AddCommand(packetTestCmd)
+	packetTestCmd.Flags().IntVar(&packetTestTimeout, "timeout", 10, "Timeout in seconds to wait for a packet")
+}
+
+func runPacketTest(cmd *cobra.Command, args []string) error {
+	// Open connection (serial or WebSocket)
+	conn, connInfo, err := OpenConnection()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Connection error: %v\n", err)
+		os.Exit(2)
+	}
+	defer conn.Close()
+
+	fmt.Printf("Heliostat - Packet Test\n")
+	fmt.Printf("Connection: %s\n", connInfo)
+	fmt.Printf("Timeout: %d seconds\n", packetTestTimeout)
+	fmt.Printf("Waiting for valid Fusain packet...\n\n")
+
+	decoder := fusain.NewDecoder()
+	buf := make([]byte, 128)
+
+	// Channel for packet reception
+	packetChan := make(chan *fusain.Packet, 1)
+	errChan := make(chan error, 1)
+
+	// Reader goroutine
+	go func() {
+		invalidBytes := 0
+		for {
+			n, err := conn.Read(buf)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			for i := 0; i < n; i++ {
+				packet, decodeErr := decoder.DecodeByte(buf[i])
+				if decodeErr != nil {
+					// Ignore decode errors, just count invalid bytes
+					invalidBytes++
+					continue
+				}
+				if packet != nil {
+					// Got a valid packet!
+					if invalidBytes > 0 {
+						fmt.Printf("(skipped %d invalid bytes before sync)\n", invalidBytes)
+					}
+					packetChan <- packet
+					return
+				}
+			}
+		}
+	}()
+
+	// Wait for packet or timeout
+	select {
+	case packet := <-packetChan:
+		fmt.Printf("SUCCESS: Received valid packet\n")
+		fmt.Printf("  Type: %s (0x%02X)\n", fusain.FormatMessageType(packet.Type()), packet.Type())
+		fmt.Printf("  Address: 0x%016X\n", packet.Address())
+		fmt.Printf("  Length: %d bytes\n", packet.Length())
+		fmt.Printf("  CRC: 0x%04X\n", packet.CRC())
+		os.Exit(0)
+
+	case err := <-errChan:
+		fmt.Fprintf(os.Stderr, "Read error: %v\n", err)
+		os.Exit(2)
+
+	case <-time.After(time.Duration(packetTestTimeout) * time.Second):
+		fmt.Fprintf(os.Stderr, "TIMEOUT: No valid packet received within %d seconds\n", packetTestTimeout)
+		os.Exit(1)
+	}
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,9 +8,14 @@ import (
 )
 
 var (
-	// Global flags
+	// Serial connection flags
 	portName string
 	baudRate int
+
+	// WebSocket connection flags
+	wsURL         string
+	wsUsername    string
+	wsNoSSLVerify bool
 )
 
 var rootCmd = &cobra.Command{
@@ -19,15 +24,27 @@ var rootCmd = &cobra.Command{
 	Long: `Heliostat - A CLI tool for monitoring and analyzing Helios serial protocol packets.
 
 Provides commands for raw packet logging and advanced error detection to help
-diagnose communication issues and protocol anomalies.`,
-	Version: "2.0.0",
+diagnose communication issues and protocol anomalies.
+
+Connection modes:
+  Serial:    --port /dev/ttyUSB0 [--baud 115200]
+  WebSocket: --url ws://host/path [--username user]
+
+For WebSocket authentication, the password is read from the FUSAIN_PASSWORD
+environment variable, or prompted interactively if not set. The --password
+flag is intentionally not provided to avoid leaking credentials in shell history.`,
+	Version: "2.1.0",
 }
 
 func init() {
-	// Global persistent flags (available to all subcommands)
-	rootCmd.PersistentFlags().StringVarP(&portName, "port", "p", "", "Serial port device (required)")
-	rootCmd.PersistentFlags().IntVarP(&baudRate, "baud", "b", 115200, "Baud rate")
-	rootCmd.MarkPersistentFlagRequired("port")
+	// Serial connection flags
+	rootCmd.PersistentFlags().StringVarP(&portName, "port", "p", "", "Serial port device")
+	rootCmd.PersistentFlags().IntVarP(&baudRate, "baud", "b", 115200, "Baud rate (serial only)")
+
+	// WebSocket connection flags
+	rootCmd.PersistentFlags().StringVarP(&wsURL, "url", "u", "", "WebSocket URL (ws:// or wss://)")
+	rootCmd.PersistentFlags().StringVar(&wsUsername, "username", "", "Username for HTTP Basic auth")
+	rootCmd.PersistentFlags().BoolVar(&wsNoSSLVerify, "no-ssl-verify", false, "Skip TLS certificate verification (wss:// only)")
 }
 
 // Execute runs the root command

--- a/cmd/ws_discovery.go
+++ b/cmd/ws_discovery.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Kaz Walker, Thermoquad
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Thermoquad/heliostat/pkg/fusain"
+	"github.com/spf13/cobra"
+)
+
+var (
+	wsDiscoveryTimeout int
+)
+
+var wsDiscoveryCmd = &cobra.Command{
+	Use:   "ws_discovery",
+	Short: "Test device discovery via WebSocket bridge",
+	Long: `Send DISCOVERY_REQUEST to the Slate WebSocket router and display DEVICE_ANNOUNCE responses.
+
+This command tests the device discovery handshake:
+  1. Send DISCOVERY_REQUEST to the router (stateless address)
+  2. Router responds with DEVICE_ANNOUNCE for each known device
+  3. Router sends end-of-discovery marker (DEVICE_ANNOUNCE with all zeros)
+
+This is useful for verifying:
+  - Slate is tracking connected devices (e.g., Helios)
+  - DEVICE_ANNOUNCE contains correct capabilities
+  - Discovery handshake completes successfully
+
+Exit codes:
+  0 - Discovery successful (at least one device found)
+  1 - Discovery failed (no devices or timeout)
+  2 - Connection error`,
+	RunE: runWsDiscovery,
+}
+
+func init() {
+	rootCmd.AddCommand(wsDiscoveryCmd)
+	wsDiscoveryCmd.Flags().IntVar(&wsDiscoveryTimeout, "timeout", 5, "Timeout in seconds for discovery")
+}
+
+func runWsDiscovery(cmd *cobra.Command, args []string) error {
+	// Open connection (serial or WebSocket)
+	conn, connInfo, err := OpenConnection()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Connection error: %v\n", err)
+		os.Exit(2)
+	}
+	defer conn.Close()
+
+	fmt.Printf("Heliostat - Device Discovery Test\n")
+	fmt.Printf("Connection: %s\n", connInfo)
+	fmt.Printf("Timeout: %d seconds\n\n", wsDiscoveryTimeout)
+
+	decoder := fusain.NewDecoder()
+
+	// Create DISCOVERY_REQUEST packet for stateless address (router)
+	discoveryPacket := fusain.NewDiscoveryRequest(fusain.AddressStateless)
+	wireBytes := fusain.MustEncodePacket(discoveryPacket)
+
+	// Send discovery request
+	fmt.Printf("Sending DISCOVERY_REQUEST...\n")
+	_, err = conn.Write(wireBytes)
+	if err != nil {
+		fmt.Printf("SEND FAILED: %v\n", err)
+		os.Exit(2)
+	}
+
+	// Collect DEVICE_ANNOUNCE responses
+	devices := make([]deviceInfo, 0)
+	done := make(chan bool, 1)
+	errChan := make(chan error, 1)
+
+	go func() {
+		buf := make([]byte, 128)
+		for {
+			n, err := conn.Read(buf)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			for j := 0; j < n; j++ {
+				packet, decodeErr := decoder.DecodeByte(buf[j])
+				if decodeErr != nil {
+					continue
+				}
+				if packet != nil {
+					msgType := packet.Type()
+					if msgType == fusain.MsgDeviceAnnounce {
+						device := parseDeviceAnnounce(packet)
+						if device.isEndMarker() {
+							fmt.Printf("\nEnd of discovery marker received\n")
+							done <- true
+							return
+						}
+						devices = append(devices, device)
+						fmt.Printf("\nDevice found:\n")
+						fmt.Printf("  Address: 0x%016X\n", device.address)
+						fmt.Printf("  Motors: %d\n", device.motorCount)
+						fmt.Printf("  Thermometers: %d\n", device.thermometerCount)
+						fmt.Printf("  Pumps: %d\n", device.pumpCount)
+						fmt.Printf("  Glow plugs: %d\n", device.glowCount)
+					}
+					// Ignore non-discovery packets (telemetry, etc.)
+				}
+			}
+		}
+	}()
+
+	// Wait for discovery to complete or timeout
+	select {
+	case <-done:
+		// Discovery complete
+	case err := <-errChan:
+		fmt.Printf("READ FAILED: %v\n", err)
+		os.Exit(2)
+	case <-time.After(time.Duration(wsDiscoveryTimeout) * time.Second):
+		fmt.Printf("\nTIMEOUT: No end-of-discovery marker received in %ds\n", wsDiscoveryTimeout)
+	}
+
+	// Summary
+	fmt.Printf("\n--- Discovery summary ---\n")
+	fmt.Printf("Devices found: %d\n", len(devices))
+
+	if len(devices) == 0 {
+		fmt.Printf("No devices discovered. Slate may not have tracked any connected devices yet.\n")
+		os.Exit(1)
+	}
+
+	return nil
+}
+
+type deviceInfo struct {
+	address          uint64
+	motorCount       uint64
+	thermometerCount uint64
+	pumpCount        uint64
+	glowCount        uint64
+}
+
+func (d deviceInfo) isEndMarker() bool {
+	return d.motorCount == 0 && d.thermometerCount == 0 && d.pumpCount == 0 && d.glowCount == 0
+}
+
+func parseDeviceAnnounce(p *fusain.Packet) deviceInfo {
+	payloadMap := p.PayloadMap()
+
+	motorCount, _ := fusain.GetMapUint(payloadMap, 0)
+	thermometerCount, _ := fusain.GetMapUint(payloadMap, 1)
+	pumpCount, _ := fusain.GetMapUint(payloadMap, 2)
+	glowCount, _ := fusain.GetMapUint(payloadMap, 3)
+
+	return deviceInfo{
+		address:          p.Address(),
+		motorCount:       motorCount,
+		thermometerCount: thermometerCount,
+		pumpCount:        pumpCount,
+		glowCount:        glowCount,
+	}
+}

--- a/cmd/ws_ping.go
+++ b/cmd/ws_ping.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Kaz Walker, Thermoquad
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Thermoquad/heliostat/pkg/fusain"
+	"github.com/spf13/cobra"
+)
+
+var (
+	wsPingTimeout int
+	wsPingCount   int
+)
+
+var wsPingCmd = &cobra.Command{
+	Use:   "ws_ping",
+	Short: "Test WebSocket bridge by sending PING_REQUEST to Slate router",
+	Long: `Send PING_REQUEST packets to the Slate WebSocket router and wait for PING_RESPONSE.
+
+This command tests bidirectional WebSocket communication with the Slate router.
+The Slate router handles PING_REQUEST locally (does not forward to Helios) and
+responds with PING_RESPONSE containing the router's uptime.
+
+This is useful for verifying:
+  - WebSocket connection is established
+  - HTTP Basic authentication works
+  - Slate router is processing packets
+  - Bidirectional packet flow works
+
+Exit codes:
+  0 - All pings successful
+  1 - One or more pings failed/timed out
+  2 - Connection error`,
+	RunE: runWsPing,
+}
+
+func init() {
+	rootCmd.AddCommand(wsPingCmd)
+	wsPingCmd.Flags().IntVar(&wsPingTimeout, "timeout", 5, "Timeout in seconds for each ping")
+	wsPingCmd.Flags().IntVar(&wsPingCount, "count", 3, "Number of pings to send")
+}
+
+func runWsPing(cmd *cobra.Command, args []string) error {
+	// Open connection (serial or WebSocket)
+	conn, connInfo, err := OpenConnection()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Connection error: %v\n", err)
+		os.Exit(2)
+	}
+	defer conn.Close()
+
+	fmt.Printf("Heliostat - WebSocket Ping Test\n")
+	fmt.Printf("Connection: %s\n", connInfo)
+	fmt.Printf("Timeout: %d seconds per ping\n", wsPingTimeout)
+	fmt.Printf("Count: %d pings\n\n", wsPingCount)
+
+	decoder := fusain.NewDecoder()
+	successCount := 0
+	failCount := 0
+
+	for i := 1; i <= wsPingCount; i++ {
+		fmt.Printf("Ping %d/%d: ", i, wsPingCount)
+
+		// Create PING_REQUEST packet for stateless address (router)
+		pingPacket := fusain.NewPingRequest(fusain.AddressStateless)
+		wireBytes := fusain.MustEncodePacket(pingPacket)
+
+		// Send ping
+		startTime := time.Now()
+		_, err := conn.Write(wireBytes)
+		if err != nil {
+			fmt.Printf("SEND FAILED: %v\n", err)
+			failCount++
+			continue
+		}
+
+		// Wait for PING_RESPONSE
+		responseChan := make(chan *fusain.Packet, 1)
+		errChan := make(chan error, 1)
+
+		go func() {
+			buf := make([]byte, 128)
+			for {
+				n, err := conn.Read(buf)
+				if err != nil {
+					errChan <- err
+					return
+				}
+
+				for j := 0; j < n; j++ {
+					packet, decodeErr := decoder.DecodeByte(buf[j])
+					if decodeErr != nil {
+						// Ignore decode errors
+						continue
+					}
+					if packet != nil {
+						// Check if it's a PING_RESPONSE
+						if packet.Type() == fusain.MsgPingResponse {
+							responseChan <- packet
+							return
+						}
+						// Ignore non-ping packets (telemetry, etc.)
+					}
+				}
+			}
+		}()
+
+		// Wait for response or timeout
+		select {
+		case packet := <-responseChan:
+			rtt := time.Since(startTime)
+			payloadMap := packet.PayloadMap()
+			uptime, _ := fusain.GetMapUint(payloadMap, 0)
+			uptimeStr := formatUptime(uptime)
+			fmt.Printf("PONG from router, uptime=%s, rtt=%v\n", uptimeStr, rtt.Round(time.Millisecond))
+			successCount++
+
+		case err := <-errChan:
+			fmt.Printf("READ FAILED: %v\n", err)
+			failCount++
+
+		case <-time.After(time.Duration(wsPingTimeout) * time.Second):
+			fmt.Printf("TIMEOUT (no response in %ds)\n", wsPingTimeout)
+			failCount++
+		}
+
+		// Small delay between pings
+		if i < wsPingCount {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	// Summary
+	fmt.Printf("\n--- Ping statistics ---\n")
+	fmt.Printf("%d pings sent, %d responses received, %.0f%% packet loss\n",
+		wsPingCount, successCount, float64(failCount)/float64(wsPingCount)*100)
+
+	if failCount > 0 {
+		os.Exit(1)
+	}
+	return nil
+}

--- a/cmd/ws_test.go
+++ b/cmd/ws_test.go
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (c) 2025 Kaz Walker, Thermoquad
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var wsTestCmd = &cobra.Command{
+	Use:   "ws_test",
+	Short: "Test raw WebSocket connection stability",
+	Long: `Test WebSocket connection to Slate without sending Fusain protocol data.
+
+This command connects to the WebSocket and just waits, logging any data received
+or errors encountered. Useful for debugging connection stability issues.
+
+Exit codes:
+  0 - Test completed normally
+  1 - Test failed
+  2 - Connection error`,
+	RunE: runWsTest,
+}
+
+var wsTestDuration int
+
+func init() {
+	rootCmd.AddCommand(wsTestCmd)
+	wsTestCmd.Flags().IntVar(&wsTestDuration, "duration", 30, "Test duration in seconds")
+}
+
+func runWsTest(cmd *cobra.Command, args []string) error {
+	// Open connection (serial or WebSocket)
+	conn, connInfo, err := OpenConnection()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Connection error: %v\n", err)
+		os.Exit(2)
+	}
+	defer conn.Close()
+
+	fmt.Printf("WebSocket Connection Stability Test\n")
+	fmt.Printf("Connection: %s\n", connInfo)
+	fmt.Printf("Duration: %d seconds\n\n", wsTestDuration)
+
+	// Start a goroutine to read from the connection
+	readChan := make(chan []byte, 100)
+	errChan := make(chan error, 1)
+
+	go func() {
+		buf := make([]byte, 256)
+		for {
+			n, err := conn.Read(buf)
+			if err != nil {
+				errChan <- err
+				return
+			}
+			if n > 0 {
+				data := make([]byte, n)
+				copy(data, buf[:n])
+				readChan <- data
+			}
+		}
+	}()
+
+	// Run for the specified duration
+	endTime := time.Now().Add(time.Duration(wsTestDuration) * time.Second)
+	bytesReceived := 0
+	packetsReceived := 0
+
+	fmt.Printf("Listening for data...\n\n")
+
+	for time.Now().Before(endTime) {
+		select {
+		case data := <-readChan:
+			bytesReceived += len(data)
+			packetsReceived++
+			fmt.Printf("[%s] Received %d bytes: %x\n",
+				time.Now().Format("15:04:05.000"), len(data), data)
+
+		case err := <-errChan:
+			fmt.Printf("\n[%s] Connection error: %v\n",
+				time.Now().Format("15:04:05.000"), err)
+			fmt.Printf("\n--- Test Results ---\n")
+			fmt.Printf("Duration: %v\n", time.Since(endTime.Add(-time.Duration(wsTestDuration)*time.Second)))
+			fmt.Printf("Packets received: %d\n", packetsReceived)
+			fmt.Printf("Bytes received: %d\n", bytesReceived)
+			fmt.Printf("Result: FAILED (connection error)\n")
+			os.Exit(1)
+
+		case <-time.After(1 * time.Second):
+			// Just a heartbeat to show the test is running
+			remaining := time.Until(endTime).Seconds()
+			fmt.Printf("[%s] Still connected... (%.0fs remaining)\n",
+				time.Now().Format("15:04:05.000"), remaining)
+		}
+	}
+
+	fmt.Printf("\n--- Test Results ---\n")
+	fmt.Printf("Duration: %d seconds\n", wsTestDuration)
+	fmt.Printf("Packets received: %d\n", packetsReceived)
+	fmt.Printf("Bytes received: %d\n", bytesReceived)
+	fmt.Printf("Result: PASSED (connection stable)\n")
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,19 @@ go 1.25.5
 
 require (
 	github.com/Thermoquad/heliostat/pkg/fusain v0.0.0
+	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/gorilla/websocket v1.5.3
 	github.com/spf13/cobra v1.10.2
 	go.bug.st/serial v1.6.4
+	golang.org/x/term v0.39.0
 )
 
 replace github.com/Thermoquad/heliostat/pkg/fusain => ./pkg/fusain
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
@@ -30,9 +34,10 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.36.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=
+github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
+github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u6mfQdFs=
+github.com/charmbracelet/bubbles v0.21.0/go.mod h1:HF+v6QUR4HkEpz62dx7ym2xc71/KBHg+zKwJtMw+qtg=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=
 github.com/charmbracelet/bubbletea v1.3.10/go.mod h1:ORQfo0fk8U+po9VaNvnV95UPWA1BitP1E0N6xJPlHr4=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=
@@ -10,6 +16,8 @@ github.com/charmbracelet/x/ansi v0.10.1 h1:rL3Koar5XvX0pHGfovN03f5cxLbCF2YvLeyz7
 github.com/charmbracelet/x/ansi v0.10.1/go.mod h1:3RQDQ6lDnROptfpWuUVIUG64bD2g2BgntdxH0Ya5TeE=
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd h1:vy0GVL4jeHEwG5YOXDmi86oYw2yuYUGqz6a8sLwg0X8=
 github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd/go.mod h1:xe0nKWGd3eJgtqZRaN9RjMtK7xUYchjzPr7q6kcvCCs=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91 h1:payRxjMjKgx2PaCWLZ4p3ro9y97+TVLZNaRZgJwSVDQ=
+github.com/charmbracelet/x/exp/golden v0.0.0-20241011142426-46044092ad91/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
@@ -21,8 +29,12 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -43,6 +55,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
@@ -60,8 +74,10 @@ golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZ
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
-golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=
+golang.org/x/sys v0.40.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.39.0 h1:RclSuaJf32jOqZz74CkPA9qFuVTX7vhLlpfj/IGWlqY=
+golang.org/x/term v0.39.0/go.mod h1:yxzUCTP/U+FzoxfdKmLaA0RV1WgE0VY7hXBwKtY/4ww=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/fusain/commands.go
+++ b/pkg/fusain/commands.go
@@ -72,3 +72,21 @@ func NewGlowCommand(address uint64, glow uint8, durationMs int32) *Packet {
 	}
 	return NewPacketWithPayload(address, MsgGlowCommand, payload)
 }
+
+// NewDiscoveryRequest creates a DISCOVERY_REQUEST packet (0x1F).
+// Routers respond with DEVICE_ANNOUNCE for each known device, followed by
+// an end-of-discovery marker (DEVICE_ANNOUNCE with all zeros).
+func NewDiscoveryRequest(address uint64) *Packet {
+	return NewPacketWithPayload(address, MsgDiscoveryRequest, nil)
+}
+
+// NewDataSubscription creates a DATA_SUBSCRIPTION packet (0x14).
+// Tells a router to forward telemetry from the specified appliance to this controller.
+// The packet address should be the router's address (or broadcast/stateless).
+// The applianceAddress is the device whose telemetry you want to receive.
+func NewDataSubscription(routerAddress uint64, applianceAddress uint64) *Packet {
+	payload := map[int]interface{}{
+		0: applianceAddress,
+	}
+	return NewPacketWithPayload(routerAddress, MsgDataSubscription, payload)
+}


### PR DESCRIPTION
## Summary

Add WebSocket connectivity and interactive control TUI for monitoring and controlling Helios heaters via serial or WebSocket (through Slate).

## Features

**Connection Support:**
- WebSocket client via `--url` flag (gorilla/websocket)
- Serial connection via existing `--port` flag
- Automatic reconnection with exponential backoff
- Password via `FUSAIN_PASSWORD` env var or interactive prompt

**Control TUI (`heliostat control`):**
- Device discovery via DEVICE_ANNOUNCE
- Multi-device support with selectable device list
- Real-time telemetry display (state, RPM, temperature, uptime)
- Fan control: RPM input + Start Fan button
- Idle control: Return to Idle button
- Router uptime display (separate from device uptime)
- Automatic ping keep-alive (5s interval)
- Statistics tracking and event log

**New Commands:**
- `control` - Interactive control TUI
- `discovery` - Device discovery utility
- `packet_test` - Packet encoding test
- `ws_test`, `ws_discovery`, `ws_ping` - WebSocket debugging utilities

**Updated Commands:**
- `error_detection` - Now supports WebSocket
- `raw_log` - Now supports WebSocket

## What's Missing (for issue #3)

- HEAT and EMERGENCY state commands
- Pump rate input for HEAT mode
- Prometheus metrics export

## Test plan

- [ ] Build: `task build`
- [ ] Test serial: `./heliostat control --port /dev/ttyUSB0`
- [ ] Test WebSocket: `./heliostat control --url ws://slate.local/fusain`
- [ ] Verify device discovery populates list
- [ ] Verify telemetry display updates
- [ ] Verify fan command works
- [ ] Verify idle command works

Partial implementation of #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)